### PR TITLE
Adding Device::double_fp_config

### DIFF
--- a/bin/ocl-info/main.cpp
+++ b/bin/ocl-info/main.cpp
@@ -94,6 +94,27 @@ print_device_info(int id, const ocl::Device & dev)
         fmt::print("        driver version: {}\n", dev.driver_version());
         fmt::print("        address bits: {}\n", dev.address_bits());
         fmt::print("        compiler available: {}\n", dev.compiler_available());
+        fmt::print("        double fp config:");
+        auto fp_cfg = dev.double_fp_config();
+        if (fp_cfg.has_flags()) {
+            fmt::print("\n");
+            if (fp_cfg & ocl::DENORM)
+                fmt::print("          - denorm\n");
+            if (fp_cfg & ocl::INF_NAN)
+                fmt::print("          - inf-nan\n");
+            if (fp_cfg & ocl::ROUND_TO_NEAREST)
+                fmt::print("          - round-to-nearest\n");
+            if (fp_cfg & ocl::ROUND_TO_ZERO)
+                fmt::print("          - round-to-zero\n");
+            if (fp_cfg & ocl::ROUND_TO_INF)
+                fmt::print("          - round-to-inf\n");
+            if (fp_cfg & ocl::FMA)
+                fmt::print("          - fma\n");
+            if (fp_cfg & ocl::SOFT_FLOAT)
+                fmt::print("          - soft-float\n");
+        }
+        else
+            fmt::print(" none\n");
         fmt::print("        global mem size: {}\n", human_size(dev.global_mem_size()));
         fmt::print("        global mem cache size: {}\n", human_size(dev.global_mem_cache_size()));
         fmt::print("        global mem cache line size: {}\n",

--- a/include/openclcpp-lite/device.h
+++ b/include/openclcpp-lite/device.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "openclcpp-lite/cl.h"
+#include "openclcpp-lite/enums.h"
 #include "openclcpp-lite/templ.h"
 #include "openclcpp-lite/error.h"
 #include <vector>
@@ -45,6 +46,9 @@ public:
     /// source. Is `true` if the compiler is available. This can be `false` for the embedded
     /// platform profile only.
     bool compiler_available() const;
+
+    /// Describes double precision floating-point capability of the OpenCL device.
+    FPConfigFlags double_fp_config() const;
 
     /// Is `true` if the device implements error correction for all accesses to compute device
     /// memory (global and constant). Is `false` if the device does not implement such error

--- a/include/openclcpp-lite/enums.h
+++ b/include/openclcpp-lite/enums.h
@@ -8,6 +8,22 @@
 
 namespace openclcpp_lite {
 
+enum FPConfig {
+    DENORM = CL_FP_DENORM,
+    INF_NAN = CL_FP_INF_NAN,
+    ROUND_TO_NEAREST = CL_FP_ROUND_TO_NEAREST,
+    ROUND_TO_ZERO = CL_FP_ROUND_TO_ZERO,
+    ROUND_TO_INF = CL_FP_ROUND_TO_INF,
+    FMA = CL_FP_FMA,
+    SOFT_FLOAT = CL_FP_SOFT_FLOAT
+};
+
+struct FPConfigFlags : public Flags<FPConfig> {
+    FPConfigFlags(const FPConfigFlags & flag);
+    FPConfigFlags(const Flags<FPConfig> & flags);
+    operator cl_device_fp_config() const;
+};
+
 enum MemoryFlag {
     READ_WRITE = CL_MEM_READ_WRITE,
     WRITE_ONLY = CL_MEM_WRITE_ONLY,

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -39,6 +39,13 @@ Device::compiler_available() const
     return get_info<cl_bool>(CL_DEVICE_COMPILER_AVAILABLE);
 }
 
+FPConfigFlags
+Device::double_fp_config() const
+{
+    auto info = get_info<cl_device_fp_config>(CL_DEVICE_DOUBLE_FP_CONFIG);
+    return FPConfigFlags(info);
+}
+
 bool
 Device::endian_little() const
 {

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -5,6 +5,15 @@
 
 namespace openclcpp_lite {
 
+FPConfigFlags::FPConfigFlags(const FPConfigFlags & flag) : Flags<FPConfig>(flag) {}
+
+FPConfigFlags::FPConfigFlags(const Flags<FPConfig> & flags) : Flags<FPConfig>(flags) {}
+
+FPConfigFlags::operator cl_device_fp_config() const
+{
+    return this->mask;
+}
+
 MemoryFlags::MemoryFlags(const MemoryFlag & flag) : Flags<MemoryFlag>(flag) {}
 
 MemoryFlags::MemoryFlags(const Flags<MemoryFlag> & flags) : Flags<MemoryFlag>(flags) {}

--- a/tests/Device_test.cpp
+++ b/tests/Device_test.cpp
@@ -11,6 +11,7 @@ TEST(DeviceTest, test)
     dev.available();
     dev.built_in_kernels();
     dev.compiler_available();
+    dev.double_fp_config();
     dev.endian_little();
     dev.error_correction_support();
     dev.extensions();


### PR DESCRIPTION
- Adding double_fp_config
- ocl-info: print double fp config values
